### PR TITLE
Add yesno message boxes to phone scripts

### DIFF
--- a/asm/macros/phone.inc
+++ b/asm/macros/phone.inc
@@ -173,6 +173,78 @@
 	.4byte \func
 	.endm
 
+	.macro phone_yesnobox
+	.byte 0x1D
+	.endm
+
+	@ Compares the values of script banks a and b, after forcing the values to bytes.
+	.macro phone_compare_local_to_local byte1:req, byte2:req
+	.byte 0x1E
+	.byte \byte1
+	.byte \byte2
+	.endm
+
+	@ Compares the least-significant byte of the value of script bank a to a fixed byte value (b).
+	.macro phone_compare_local_to_value a:req, b:req
+	.byte 0x1F
+	.byte \a
+	.byte \b
+	.endm
+
+	@ Compares the least-significant byte of the value of script bank a to the byte located at offset b.
+	.macro phone_compare_local_to_addr a:req, b:req
+	.byte 0x20
+	.byte \a
+	.4byte \b
+	.endm
+
+	@ Compares the byte located at offset a to the least-significant byte of the value of script bank b.
+	.macro phone_compare_addr_to_local a:req, b:req
+	.byte 0x21
+	.4byte \a
+	.byte \b
+	.endm
+
+	@ Compares the byte located at offset a to a fixed byte value (b).
+	.macro phone_compare_addr_to_value a:req, b:req
+	.byte 0x22
+	.4byte \a
+	.byte \b
+	.endm
+
+	@ Compares the byte located at offset a to the byte located at offset b.
+	.macro phone_compare_addr_to_addr a:req, b:req
+	.byte 0x23
+	.4byte \a
+	.4byte \b
+	.endm
+
+	@ Compares the value of `var` to a fixed word value (b).
+	.macro phone_compare_var_to_value var:req, value:req
+	.byte 0x24
+	.2byte \var
+	.2byte \value
+	.endm
+
+	@ Compares the value of `var1` to the value of `var2`.
+	.macro phone_compare_var_to_var var1:req, var2:req
+	.byte 0x25
+	.2byte \var1
+	.2byte \var2
+	.endm
+
+	@ Generic compare macro which attempts to deduce argument types based on their values
+	@ Any values between 0x4000 to 0x4FFF and 0x8000 to 0x8FFF are considered event variable identifiers
+	.macro phone_compare arg1:req, arg2:req
+		.if ((\arg1 >> 12) == 4 || (\arg1 >> 12) == 8) && ((\arg2 >> 12) == 4 || (\arg2 >> 12) == 8)
+			phone_compare_var_to_var \arg1, \arg2
+		.elseif ((\arg1 >> 12) == 4 || (\arg1 >> 12) == 8) && (\arg2 >= 0 && \arg2 <= 0xFFFF)
+			phone_compare_var_to_value \arg1, \arg2
+		.else
+			.error "Invalid arguments for 'phone_compare'"
+		.endif
+	.endm
+
 @ Supplementary
 
 	.macro phone_goto_if_unset flag:req, dest:req

--- a/data/phone_script_cmd_table.inc
+++ b/data/phone_script_cmd_table.inc
@@ -29,6 +29,15 @@ gPhoneScriptCmdTable::
 	.4byte PhoneScrCmd_waitbuttonpress
 	.4byte PhoneScrCmd_end_if_not_available
 	.4byte PhoneScrCmd_callnativecontext
+	.4byte PhoneScrCmd_yesnobox
+	.4byte PhoneScrCmd_compare_local_to_local
+	.4byte PhoneScrCmd_compare_local_to_value
+	.4byte PhoneScrCmd_compare_local_to_addr
+	.4byte PhoneScrCmd_compare_addr_to_local
+	.4byte PhoneScrCmd_compare_addr_to_value
+	.4byte PhoneScrCmd_compare_addr_to_addr
+	.4byte PhoneScrCmd_compare_var_to_value
+	.4byte PhoneScrCmd_compare_var_to_var
 
 gPhoneScriptCmdTableEnd::
 	.4byte PhoneScrCmd_nop

--- a/include/match_call.h
+++ b/include/match_call.h
@@ -23,5 +23,6 @@ void sub_8197080(u8 *destStr);
 void sub_8197184(u32 windowId, u32 destOffset, u32 paletteId);
 void sub_81971C4(u32 windowId, u32 tileOffset, u32 paletteId);
 bool32 CleanupAfterMatchCallHangup(void);
+void DrawMatchCallTextBoxBorder(u32 windowId, u32 tileOffset, u32 paletteId);
 
 #endif //GUARD_MATCH_CALL_H

--- a/include/menu.h
+++ b/include/menu.h
@@ -18,6 +18,13 @@ struct MenuAction
     } func;
 };
 
+enum
+{
+	YESNO_STANDARD,
+	YESNO_PHONE_OVERWORLD,
+	YESNO_PHONE_POKEGEAR,
+};
+
 extern const u16 gUnknown_0860F074[];
 
 void FreeAllOverworldWindowBuffers(void);
@@ -55,6 +62,7 @@ void *decompress_and_copy_tile_data_to_vram(u8 bgId, const void *src, u32 size, 
 bool8 free_temp_tile_data_buffers_if_possible(void);
 struct WindowTemplate CreateWindowTemplate(u8 bg, u8 left, u8 top, u8 width, u8 height, u8 paletteNum, u16 baseBlock);
 void CreateYesNoMenu(const struct WindowTemplate *windowTemplate, u16 borderFirstTileNum, u8 borderPalette, u8 initialCursorPos);
+void CreatePhoneYesNoMenu(const struct WindowTemplate *windowTemplate, u16 borderFirstTileNum, u8 borderPalette, u8 initialCursorPos, bool8 fromOverworld);
 void DecompressAndLoadBgGfxUsingHeap(u8 bgId, const void *src, u32 size, u16 offset, u8 mode);
 s8 Menu_ProcessInputNoWrapClearOnChoose(void);
 s8 ProcessMenuInput_other(void);

--- a/include/pokegear.h
+++ b/include/pokegear.h
@@ -8,5 +8,7 @@ extern const struct SpriteSheet sSpriteSheet_DigitTiles;
 void CB2_InitPokegear(void);
 void InitPokegearPhoneCall(u8 taskId);
 void HangupPokegearPhoneCall(void);
+void DrawPhoneCallTextBoxBorder(u32 windowId, u32 tileOffset, u32 paletteId);
+void PhoneCard_RefreshContactList(void);
 
 #endif //GUARD_POKEGEAR_H

--- a/src/match_call.c
+++ b/src/match_call.c
@@ -97,7 +97,6 @@ static int GetTrainerMatchCallId(int);
 static u16 GetRematchTrainerLocation(int);
 static bool32 TrainerIsEligibleForRematch(int);
 static void StartMatchCall(void);
-static void DrawMatchCallTextBoxBorder(u32, u32, u32);
 static void InitMatchCallCallerNameTextPrinter(int, const u8 *);
 static const struct MatchCallText *GetSameRouteMatchCallText(int, u8 *);
 static const struct MatchCallText *GetDifferentRouteMatchCallText(int, u8 *);
@@ -1449,7 +1448,7 @@ bool32 CleanupAfterMatchCallHangup(void)
 //     return FALSE;
 // }
 
-static void DrawMatchCallTextBoxBorder(u32 windowId, u32 tileOffset, u32 paletteId)
+void DrawMatchCallTextBoxBorder(u32 windowId, u32 tileOffset, u32 paletteId)
 {
     int bg, x, y, width, height;
     int tileNum;

--- a/src/menu.c
+++ b/src/menu.c
@@ -6,11 +6,13 @@
 #include "event_data.h"
 #include "field_specials.h"
 #include "graphics.h"
+#include "match_call.h"
 #include "main.h"
 #include "menu.h"
 #include "menu_helpers.h"
 #include "palette.h"
 #include "pokedex.h"
+#include "pokegear.h"
 #include "pokemon_icon.h"
 #include "region_map.h"
 #include "sound.h"
@@ -1840,12 +1842,29 @@ void sub_81995E4(u8 windowId, u8 itemCount, const struct MenuAction *strs, const
     CopyWindowToVram(windowId, 2);
 }
 
-void CreateYesNoMenu(const struct WindowTemplate *window, u16 baseTileNum, u8 paletteNum, u8 initialCursorPos)
+static void _CreateYesNoMenu(const struct WindowTemplate *window, u16 baseTileNum, u8 paletteNum, u8 initialCursorPos, u8 type)
 {
     struct TextPrinterTemplate printer;
 
     sYesNoWindowId = AddWindow(window);
-    DrawStdFrameWithCustomTileAndPalette(sYesNoWindowId, TRUE, baseTileNum, paletteNum);
+    switch (type)
+    {
+    case YESNO_STANDARD:
+        DrawStdFrameWithCustomTileAndPalette(sYesNoWindowId, TRUE, baseTileNum, paletteNum);
+        break;
+    case YESNO_PHONE_OVERWORLD:
+        DrawMatchCallTextBoxBorder(sYesNoWindowId, baseTileNum, paletteNum);
+        FillWindowPixelBuffer(sYesNoWindowId, PIXEL_FILL(1));
+        PutWindowTilemap(sYesNoWindowId);
+        CopyWindowToVram(sYesNoWindowId, 3);
+        break;
+    case YESNO_PHONE_POKEGEAR:
+        DrawPhoneCallTextBoxBorder(sYesNoWindowId, baseTileNum, paletteNum);
+        FillWindowPixelBuffer(sYesNoWindowId, PIXEL_FILL(1));
+        PutWindowTilemap(sYesNoWindowId);
+        CopyWindowToVram(sYesNoWindowId, 3);
+        break;
+    }
 
     printer.currentChar = gText_YesNo;
     printer.windowId = sYesNoWindowId;
@@ -1863,6 +1882,17 @@ void CreateYesNoMenu(const struct WindowTemplate *window, u16 baseTileNum, u8 pa
 
     AddTextPrinter(&printer, 0xFF, NULL);
     InitMenuInUpperLeftCornerPlaySoundWhenAPressed(sYesNoWindowId, 2, initialCursorPos);
+}
+
+void CreateYesNoMenu(const struct WindowTemplate *window, u16 baseTileNum, u8 paletteNum, u8 initialCursorPos)
+{
+    _CreateYesNoMenu(window, baseTileNum, paletteNum, initialCursorPos, YESNO_STANDARD);
+}
+
+void CreatePhoneYesNoMenu(const struct WindowTemplate *window, u16 baseTileNum, u8 paletteNum, u8 initialCursorPos, bool8 fromOverworld)
+{
+    u8 type = fromOverworld ? YESNO_PHONE_OVERWORLD : YESNO_PHONE_POKEGEAR;
+    _CreateYesNoMenu(window, baseTileNum, paletteNum, initialCursorPos, type);
 }
 
 void PrintMenuGridTable(u8 windowId, u8 optionWidth, u8 columns, u8 rows, const struct MenuAction *strs)

--- a/src/pokegear.c
+++ b/src/pokegear.c
@@ -112,7 +112,6 @@ static void PhoneCard_ConfirmCallProcessInput(u8 taskId);
 static void PhoneCard_AddScrollIndicators(u8 taskId);
 static void PhoneCard_ReturnToMain(u8 taskId);
 static void PhoneCard_PlaceCall(u8 taskId);
-static void DrawPhoneCallTextBoxBorder(u32 windowId, u32 tileOffset, u32 paletteId);
 static void UpdateRadioStation(u8 taskId, u8 frequency);
 static void LoadCardSprites(u8 taskId);
 static void SpriteCB_Icons(struct Sprite* sprite);
@@ -1282,6 +1281,11 @@ static void PhoneCard_ConfirmCallProcessInput(u8 taskId)
     }
 }
 
+void PhoneCard_RefreshContactList(void)
+{
+    PutWindowTilemap(WIN_LIST);
+}
+
 static void PhoneCard_ReturnToMain(u8 taskId)
 {
     ShowHelpBar(gText_PhoneCardHelp1);
@@ -1389,7 +1393,7 @@ void InitPokegearPhoneCall(u8 taskId)
     }
 }
 
-static void DrawPhoneCallTextBoxBorder(u32 windowId, u32 tileOffset, u32 paletteId)
+void DrawPhoneCallTextBoxBorder(u32 windowId, u32 tileOffset, u32 paletteId)
 {
     int bg, x, y, width, height;
     int tileNum;

--- a/src/script.c
+++ b/src/script.c
@@ -25,8 +25,6 @@ extern ScrCmdFunc gScriptCmdTable[];
 extern ScrCmdFunc gScriptCmdTableEnd[];
 extern void *gNullScriptPtr;
 
-static void ReturnFromPhoneScript(void);
-
 void InitScriptContext(struct ScriptContext *ctx, void *cmdTable, void *cmdTableEnd)
 {
     s32 i;


### PR DESCRIPTION
Example:
```
Route30_PhoneScript_ElmCall::
	phone_initcall
	phone_end_if_not_available
	phone_message Route30_Text_ElmCall
	phone_yesnobox
	phone_compare VAR_RESULT, 0
	phone_goto_if_eq Route30_PhoneScript_ElmCall_SaidNo
	phone_message Route30_Text_ElmCall_Yes
	phone_waitbuttonpress
	phone_hangup
	phone_end

Route30_PhoneScript_ElmCall_SaidNo:
	phone_message Route30_Text_ElmCall_No
	phone_waitbuttonpress
	phone_hangup
	phone_end

Route30_Text_ElmCall:
	.string "H-hello? {PLAYER}?\n"
	.string "It's a disaster!\p"
	.string "Uh, um, it's just terrible!\p"
	.string "What should I do?\n"
	.string "It… Oh, no…\p"
	.string "Please get back here now!$"

Route30_Text_ElmCall_No:
	.string "You said NO!$"

Route30_Text_ElmCall_Yes:
	.string "You said YES!$"
```