### PR TITLE
Update gbs.c to fix a building issue

### DIFF
--- a/src/gbs.c
+++ b/src/gbs.c
@@ -701,11 +701,11 @@ static void LoadWavePattern(struct GBSTrack *track, int patternID)
         *length = 0x3F;
         *control = 0x40; // Stop channel and choose other wave bank so we can write into the first one
 
-        if (patternID < ARRAY_COUNT(sWaveTrackPatterns) && soundInfo->cgbChans[CGBCHANNEL_WAVE].currentPointer != (u32)sWaveTrackPatterns[patternID])
+        if (patternID < ARRAY_COUNT(sWaveTrackPatterns) && soundInfo->cgbChans[CGBCHANNEL_WAVE].currentPointer != (u32 *)sWaveTrackPatterns[patternID])
         {
             u32* mainPattern = (u32 *)(REG_ADDR_WAVE_RAM0);
             memcpy(mainPattern, sWaveTrackPatterns[patternID], sizeof(sWaveTrackPatterns[patternID]));
-            soundInfo->cgbChans[CGBCHANNEL_WAVE].currentPointer = (u32)sWaveTrackPatterns[patternID];
+            soundInfo->cgbChans[CGBCHANNEL_WAVE].currentPointer = (u32 *)sWaveTrackPatterns[patternID];
         }
 
         *velocity = track->velocity << 5;


### PR DESCRIPTION
Before making those 2 changes, the make modern command was outputting that error:

src/gbs.c:704:151: warning: comparison between pointer and integer
  704 |         if (patternID < ARRAY_COUNT(sWaveTrackPatterns) && soundInfo->cgbChans[CGBCHANNEL_WAVE].currentPointer != (u32)sWaveTrackPatterns[patternID])
      |                                                                                                                                                       ^
src/gbs.c:708:65: error: assignment to 'u32 *' {aka 'long unsigned int *'} from 'long unsigned int' makes pointer from integer without a cast [-Wint-conversion]tools/gbagfx/gbagfx.exe graphics/battle_anims/backgrounds/drill.png graphics/battle_anims/backgrounds/drill.4bpp

  708 |             soundInfo->cgbChans[CGBCHANNEL_WAVE].currentPointer = (u32)sWaveTrackPatterns[patternID];